### PR TITLE
Improved Visuals and Voice Commands

### DIFF
--- a/Model.py
+++ b/Model.py
@@ -1,9 +1,12 @@
 import json
 import os
-import dearpygui as dpg
+from dearpygui import dearpygui as dpg
 import json
 import os
 import Control
+
+dpg.create_context()
+
 
 def save_deployment_gear(gear_name, filename="deployment_gear.json"):
     """Saves a gear name to a JSON list if it doesn't already exist."""
@@ -149,7 +152,7 @@ def get_sorted_times_by_key(key_name: str, file_path: str = "deployment_scores.j
         Control._check_window_exists(popup_tag)
 
         with dpg.window(label="Error", modal=True, tag=popup_tag, width=300, height=120, no_resize=True, pos=(200, 200)):
-            dpg.add_text(f"'{key_name}' not found in file.")
+            dpg.add_text("No data to graph")
             dpg.add_spacing(count=2)
             dpg.add_button(label="OK", width=75, callback=lambda: Control._delete_window(popup_tag))
 
@@ -159,8 +162,8 @@ def get_sorted_times_by_key(key_name: str, file_path: str = "deployment_scores.j
     result = []
 
     for t in time_list:
-        if isinstance(t, str) and t.strip().lower() == "botched":
-            result.append({"original": t, "milliseconds": "botched"})
+        if isinstance(t, str) and t.strip().lower() == "eightysix":
+            result.append({"original": t, "milliseconds": "EightySix"})
         else:
             try:
                 ms = time_to_milliseconds(t)

--- a/View_GearUI_TrainingOptions.py
+++ b/View_GearUI_TrainingOptions.py
@@ -42,7 +42,7 @@ def start(sender, app_data, user_data):
 
         with dpg.group(horizontal=True):
                 dpg.add_spacer(width=padding)
-                dpg.add_button(label="Performance Tracking",tag="performance_tracking_button", callback=View_GearUI_TrainingOptions_Track.show_training_graph, width=button_width, height=100, user_data=gear)
+                dpg.add_button(label="Graph",tag="performance_tracking_button", callback=View_GearUI_TrainingOptions_Track.show_training_graph, width=button_width, height=100, user_data=gear)
                 dpg.bind_item_theme("performance_tracking_button", red_button_theme)           
         with dpg.group(horizontal=True):
                 dpg.add_spacer(width=padding)

--- a/View_GearUI_TrainingOptions_Track.py
+++ b/View_GearUI_TrainingOptions_Track.py
@@ -53,14 +53,14 @@ def show_training_graph(sender=None, app_data=None, user_data=None):
 
     for entry in training_data:
         ms = entry["milliseconds"]
-        if ms == "botched":
+        if ms == "EightySix":
             if current_x and current_y:
                 line_segments.append((current_x, current_y))
                 current_x, current_y = [], []
             if prev_y is not None:
                 botched_x.append(session_index)
                 botched_y.append(prev_y)
-                annotations.append((session_index, prev_y, "BOTCHED"))
+                annotations.append((session_index, prev_y, "EightySix"))
         else:
             y_val = ms / 1000
             total_time += ms
@@ -127,7 +127,7 @@ def show_training_graph(sender=None, app_data=None, user_data=None):
             dpg.add_scatter_series(scatter_x, scatter_y, label="Time", tag=scatter_tag, parent=y_axis_tag)
 
             if botched_x:
-                dpg.add_scatter_series(botched_x, botched_y, label="Botched", tag=botched_tag, parent=y_axis_tag)
+                dpg.add_scatter_series(botched_x, botched_y, label="EightySix", tag=botched_tag, parent=y_axis_tag)
 
         # Below the plot
         with dpg.group(horizontal=True):

--- a/View_GearUI_TrainingOptions_Train.py
+++ b/View_GearUI_TrainingOptions_Train.py
@@ -41,13 +41,13 @@ def start_timer():
         timer_running = True
         update_timer()
 
-def stop_timer_internal(botched = False):
+def stop_timer_internal(eighty_six = False):
     global timer_running
     timer_running = False
-    if not botched:
+    if not eighty_six:
         Model.save_deployment_gear_time(dpg.get_value(timer_display_tag), gear)
     else:
-        Model.save_deployment_gear_time("botched", gear)
+        Model.save_deployment_gear_time("EightySix", gear)
 
 def reset_timer():
     global timer_running, elapsed_time
@@ -147,8 +147,8 @@ def listen_for_commands():
                 current_round += 1
                 Control.play_sound("assets/audio/heard.wav")
                 break
-            elif speech.endswith("botch") or speech == "botch":
-                stop_timer_internal(botched=True)
+            elif speech.endswith("eighty") or speech == "eightysix":
+                stop_timer_internal(eighty_six=True)
                 Control.play_sound("assets/audio/heard.wav")
                 break
 

--- a/View_HomeUI.py
+++ b/View_HomeUI.py
@@ -140,7 +140,7 @@ def _create_homeUI():
                     dpg.add_theme_color(dpg.mvThemeCol_ChildBg, (0, 0, 0, 0))
 
             # === Middle Pane ===
-            with dpg.child_window(width=390, height=400, border=False, tag="tag_middle_pane"):
+            with dpg.child_window(width=370, height=400, border=False, tag="tag_middle_pane"):
                 dpg.bind_item_theme("tag_middle_pane", middle_theme)
 
                 with dpg.group(horizontal=True):
@@ -157,15 +157,15 @@ def _create_homeUI():
                 dpg.add_spacer(height=280)
 
                 with dpg.group(horizontal=False):
-                    plus_btn = dpg.add_button(label="+", callback=_show_input_field,
+                    plus_btn = dpg.add_button(label="Add", callback=_show_input_field,
                                               user_data=[button_container,"add"])
                     dpg.bind_item_theme(plus_btn, red_button_theme)
 
-                    minus_btn = dpg.add_button(label="-", callback=_show_input_field,
+                    minus_btn = dpg.add_button(label="Remove", callback=_show_input_field,
                                                user_data=[button_container,"remove"])
                     dpg.bind_item_theme(minus_btn, red_button_theme)
 
-                    exclaim_btn = dpg.add_button(label="!", callback=Control._nuke_gear)
+                    exclaim_btn = dpg.add_button(label="Nuke", callback=Control._nuke_gear)
                     dpg.bind_item_theme(exclaim_btn, red_button_theme)
 
                 savedGear = Model.load_deployment_gear()


### PR DESCRIPTION
So "Botched" verbal command is replaced with "Eighty-Six". Also so the Home UI buttons to remove, add and nuke gear are visually replaced to words instead of symbols. and window size in the Home UI is adjusted to accommodate for said new labels. Also so the "Performance Tracking" button in the training options has its label replaced to "Graph" for easier understanding from the user. Also so the incorrect dearpygui import and missing initialization for dearpygui is fixed in the Model.py. Finally so the popup text for when there is nothing to graph is more understandable by the user.